### PR TITLE
rely on env variable to fix race condition with workspace file

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -2,7 +2,7 @@ bind = "0.0.0.0:80"
 chdir = "/www"
 loglevel = "error"
 workers = "1"
-worker_class = "gevent"
+worker_class = "sync"
 threads = "1"
 
 errorlog = "-"

--- a/terraformize/terraformize_terraform_wrapper.py
+++ b/terraformize/terraformize_terraform_wrapper.py
@@ -20,11 +20,8 @@ class Terraformize:
         # we need to init for a remote backend before we can create a workspace
         self.init_return_code, self.init_stdout, self.init_stderr = self.tf.init(dir_or_plan=folder_path)
 
-        # always create the workspace and switch to it, if workspace already created carries on when it failed creating
-        # it again
-        self.tf.create_workspace(workspace=workspace)
-        self.workspace_return_code, self.workspace_stdout, self.workspace_stderr = \
-            self.tf.set_workspace(workspace=workspace)
+        # terraform will create the workspace if it doesnt exist
+        os.environ['TF_WORKSPACE'] = workspace
 
     def apply(self, variables: Optional[dict] = None, parallelism: int = 10) -> Tuple[str, str, str]:
         """

--- a/test/test_terraformize_terraform_wrapper.py
+++ b/test/test_terraformize_terraform_wrapper.py
@@ -15,13 +15,13 @@ class BaseTests(TestCase):
     def test_terraformize_terraform_wrapper_init_create_and_use_new_workspace(self):
         terraform_object = Terraformize("test_workspace", "/tmp/", terraform_bin_path=test_bin_location)
         self.assertEqual(terraform_object.init_return_code, 0)
-        self.assertEqual(terraform_object.workspace_return_code, 0)
+        self.assertEqual(os.getenv("TF_WORKSPACE"), "test_workspace")
 
     def test_terraformize_terraform_wrapper_init_use_preexisting_workspace(self):
         Terraformize("test_workspace", "/tmp/", terraform_bin_path=test_bin_location)
         terraform_object = Terraformize("test_workspace", "/tmp/", terraform_bin_path=test_bin_location)
         self.assertEqual(terraform_object.init_return_code, 0)
-        self.assertEqual(terraform_object.workspace_return_code, 0)
+        self.assertEqual(os.getenv("TF_WORKSPACE"), "test_workspace")
 
     def test_terraformize_terraform_wrapper_apply_no_vars(self):
         terraform_object = Terraformize("test_workspace", test_files_location, terraform_bin_path=test_bin_location)


### PR DESCRIPTION
 this fixes 1 of 2 concurrency issues defined in #17