### PR TITLE
chore: update Dockerfile to reduce the image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY --from=terraform /bin/terraform /usr/local/bin/terraform
 COPY config/config.py /etc/gunicorn/config.py
 
 COPY requirements.txt /www/requirements.txt
-RUN pip install -r /www/requirements.txt
+RUN pip install --no-cache-dir -r /www/requirements.txt
 
 # copy the codebase
 COPY . /www


### PR DESCRIPTION
Hi there,

I've made a small improvement to the Dockerfile that I think could help optimize the image size.

The change I made:
* I added the `--no-cache-dir` to the `pip` command to disable the package cache.


Impact on the image size:
* Image size before repair: 131.89 MB
* Image size after repair: 127.91 MB
* Difference: 3.98 MB (3.02%)

I hope that you will find these changes useful to you. Let me know if you have any questions or concerns.

Thanks,
